### PR TITLE
Validator: assay and assay data checks

### DIFF
--- a/converter/datamodel.py
+++ b/converter/datamodel.py
@@ -190,7 +190,7 @@ class SeqAssay(Assay):
 
         # Get platform and instrument from sequencing protocol
         for p in protocols:
-            if p.get("title") in protocolrefs and p.get("protocol type") == "nucleic acid sequencing protocol":
+            if p.get("title") in protocolrefs and p.get("protocol_type") == "nucleic acid sequencing protocol":
                 hardware = p.get("hardware")
                 lib_attribs["instrument_model"] = hardware
                 # TODO: need to look up the platform type from ENA's controlled vocab

--- a/magetab_validation.py
+++ b/magetab_validation.py
@@ -26,18 +26,21 @@ def parse_args():
                         help="Option to output detailed logging (debug level).")
     args = parser.parse_args()
 
-    return args.idf, args.data_dir, args.verbose
+    return args
 
 
 def main():
     process_name = "magetab_validation"
 
-    idf_file, data_dir, detail = parse_args()
+    args = parse_args()
+    idf_file, data_dir, logging_level = args.idf, args.data_dir, args.verbose
+
+    # Exit if IDF file doesn't exist
     file_exists(idf_file)
 
     # Create logger
     current_dir, idf_file_name = os.path.split(idf_file)
-    logger = create_logger(current_dir, process_name, idf_file_name, logger_name="Validation", log_level=detail)
+    logger = create_logger(current_dir, process_name, idf_file_name, logger_name="Validation", log_level=logging_level)
 
     # Get path to SDRF file
     sdrf_file_path = get_sdrf_path(idf_file, logger, data_dir)
@@ -51,7 +54,7 @@ def main():
     logger.info("Found experiment type: {}".format(submission_type))
 
     # Logger for prevalidation (create new to show different styling)
-    mtab_logger = create_logger(current_dir, process_name, idf_file_name, logger_name="MAGE-TAB", log_level=detail)
+    mtab_logger = create_logger(current_dir, process_name, idf_file_name, logger_name="MAGE-TAB", log_level=logging_level)
 
     # Perform prevalidation checks on MAGE-TAB format
     pre.idf_prevalidation(idf_dict, mtab_logger)
@@ -64,7 +67,7 @@ def main():
     error_codes = []
 
     # Logger for metadata validation output
-    metadata_logger = create_logger(current_dir, process_name, idf_file_name, logger_name="Metadata", log_level=detail)
+    metadata_logger = create_logger(current_dir, process_name, idf_file_name, logger_name="Metadata", log_level=logging_level)
 
     # Validate metadata in common data model
     error_codes.extend(mv.run_project_checks(sub, metadata_logger))

--- a/magetab_validation.py
+++ b/magetab_validation.py
@@ -22,21 +22,22 @@ def parse_args():
                         help="Path to the MAGE-TAB IDF file")
     parser.add_argument('-d', "--data_dir", default="",
                         help="Path to the directory with SDRF and data files")
-
+    parser.add_argument('-v', '--verbose', action='store_const', const=10, default=20,
+                        help="Option to output detailed logging (debug level).")
     args = parser.parse_args()
 
-    return args.idf, args.data_dir
+    return args.idf, args.data_dir, args.verbose
 
 
 def main():
     process_name = "magetab_validation"
 
-    idf_file, data_dir = parse_args()
+    idf_file, data_dir, detail = parse_args()
     file_exists(idf_file)
 
     # Create logger
     current_dir, idf_file_name = os.path.split(idf_file)
-    logger = create_logger(current_dir, process_name, idf_file_name, logger_name="Validation")
+    logger = create_logger(current_dir, process_name, idf_file_name, logger_name="Validation", log_level=detail)
 
     # Get path to SDRF file
     sdrf_file_path = get_sdrf_path(idf_file, logger, data_dir)
@@ -50,7 +51,7 @@ def main():
     logger.info("Found experiment type: {}".format(submission_type))
 
     # Logger for prevalidation (create new to show different styling)
-    mtab_logger = create_logger(current_dir, process_name, idf_file_name, logger_name="MAGE-TAB")
+    mtab_logger = create_logger(current_dir, process_name, idf_file_name, logger_name="MAGE-TAB", log_level=detail)
 
     # Perform prevalidation checks on MAGE-TAB format
     pre.idf_prevalidation(idf_dict, mtab_logger)
@@ -63,7 +64,7 @@ def main():
     error_codes = []
 
     # Logger for metadata validation output
-    metadata_logger = create_logger(current_dir, process_name, idf_file_name, logger_name="Metadata")
+    metadata_logger = create_logger(current_dir, process_name, idf_file_name, logger_name="Metadata", log_level=detail)
 
     # Validate metadata in common data model
     error_codes.extend(mv.run_project_checks(sub, metadata_logger))

--- a/magetab_validation.py
+++ b/magetab_validation.py
@@ -6,7 +6,6 @@ This script takes an IDF file as input and runs validation of the metadata in th
 
 import argparse
 import os
-import logging
 
 from utils.common_utils import create_logger, file_exists
 from utils.converter_utils import get_sdrf_path, guess_submission_type_from_sdrf, guess_submission_type_from_idf, \

--- a/magetab_validation.py
+++ b/magetab_validation.py
@@ -72,6 +72,7 @@ def main():
     error_codes.extend(mv.run_protocol_checks(sub, metadata_logger))
     error_codes.extend(mv.run_sample_checks(sub, metadata_logger))
     error_codes.extend(mv.run_assay_checks(sub, metadata_logger))
+    error_codes.extend(mv.run_file_checks(sub, metadata_logger))
 
     if error_codes:
         logger.info("Validation finished with the following error codes: \n{}".format("\n".join(set(error_codes))))

--- a/magetab_validation.py
+++ b/magetab_validation.py
@@ -19,17 +19,19 @@ import validator.metadata_validation as mv
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('idf',
-                        help="name of MAGE-TAB IDF file")
+                        help="Path to the MAGE-TAB IDF file")
+    parser.add_argument('-d', "--data_dir", default="",
+                        help="Path to the directory with SDRF and data files")
 
     args = parser.parse_args()
 
-    return args.idf
+    return args.idf, args.data_dir
 
 
 def main():
     process_name = "magetab_validation"
 
-    idf_file = parse_args()
+    idf_file, data_dir = parse_args()
     file_exists(idf_file)
 
     # Create logger
@@ -37,7 +39,7 @@ def main():
     logger = create_logger(current_dir, process_name, idf_file_name, logger_name="Validation")
 
     # Get path to SDRF file
-    sdrf_file_path = get_sdrf_path(idf_file, logger)
+    sdrf_file_path = get_sdrf_path(idf_file, logger, data_dir)
 
     # Read IDF/SDRF and get submission type
     idf_dict = read_idf_file(idf_file)

--- a/tests/test_api_calls.py
+++ b/tests/test_api_calls.py
@@ -2,7 +2,7 @@ import unittest
 import os
 
 from utils.converter_utils import get_taxon
-from utils.common_utils import get_term_descendants, create_logger
+from utils.common_utils import get_term_descendants, create_logger, get_ena_library_terms_via_usi
 
 
 class TestTaxonRetrieval(unittest.TestCase):
@@ -32,6 +32,18 @@ class TestOntologyTermRetrieval(unittest.TestCase):
         ontology = "EFO"
         terms = get_term_descendants(ontology, uri, self.logger)
         self.assertIn("colony forming unit", terms)
+
+
+class TestRetrievingENAlibraryTerms(unittest.TestCase):
+
+    def setUp(self):
+        wd = os.path.dirname(os.path.realpath(__file__))
+        # Add logger to hold error messages
+        self.logger = create_logger(wd, "testing", "validation", 10)
+
+    def test_library_layout_cv(self):
+        library_terms = get_ena_library_terms_via_usi(self.logger)
+        self.assertIn("SINGLE", library_terms["library_layout"])
 
 
 if __name__ == '__main__':

--- a/tests/test_api_calls.py
+++ b/tests/test_api_calls.py
@@ -2,7 +2,10 @@ import unittest
 import os
 
 from utils.converter_utils import get_taxon
-from utils.common_utils import get_term_descendants, create_logger, get_ena_library_terms_via_usi
+from utils.common_utils import create_logger, \
+    get_term_descendants, \
+    get_ena_library_terms_via_usi, \
+    get_ena_hardware_terms_via_usi
 
 
 class TestTaxonRetrieval(unittest.TestCase):
@@ -44,6 +47,10 @@ class TestRetrievingENAlibraryTerms(unittest.TestCase):
     def test_library_layout_cv(self):
         library_terms = get_ena_library_terms_via_usi(self.logger)
         self.assertIn("SINGLE", library_terms["library_layout"])
+
+    def test_hardware_cv(self):
+        hardware_terms = get_ena_hardware_terms_via_usi(self.logger)
+        self.assertIn("Illumina HiSeq 2500", hardware_terms)
 
 
 if __name__ == '__main__':

--- a/tests/test_api_calls.py
+++ b/tests/test_api_calls.py
@@ -5,7 +5,7 @@ from utils.converter_utils import get_taxon
 from utils.common_utils import create_logger, \
     get_term_descendants, \
     get_ena_library_terms_via_usi, \
-    get_ena_hardware_terms_via_usi
+    get_ena_instrument_terms_via_usi
 
 
 class TestTaxonRetrieval(unittest.TestCase):
@@ -49,7 +49,7 @@ class TestRetrievingENAlibraryTerms(unittest.TestCase):
         self.assertIn("SINGLE", library_terms["library_layout"])
 
     def test_hardware_cv(self):
-        hardware_terms = get_ena_hardware_terms_via_usi(self.logger)
+        hardware_terms = get_ena_instrument_terms_via_usi(self.logger)
         self.assertIn("Illumina HiSeq 2500", hardware_terms)
 
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -142,10 +142,21 @@ class TestMetaDataValidation(unittest.TestCase):
         self.sub.assay[1].technology_type = ""
         # Changing technology type to unknown type should give ASSA-E04
         self.sub.assay[2].technology_type = "whatever"
+        # Changing array design to non AE accession should give ASSA-E08
+        self.sub.assay[1].array_design = "this is not in AE"
         error_codes = metadata_validation.run_assay_checks(self.sub, self.logger)
         self.assertIn("ASSA-E02", error_codes)
         self.assertIn("ASSA-E03", error_codes)
         self.assertIn("ASSA-E04", error_codes)
+        self.assertIn("ASSA-E08", error_codes)
+
+        # Deleting label should give ASSA-E06
+        self.sub.assay[1].label = ""
+        # Deleting array design should give ASSA-E07
+        self.sub.assay[1].array_design = ""
+        error_codes = metadata_validation.run_assay_checks(self.sub, self.logger)
+        self.assertIn("ASSA-E06", error_codes)
+        self.assertIn("ASSA-E07", error_codes)
 
         # Deleting all assays should give error ASSA-E01
         self.sub.assay = []

--- a/utils/common_utils.py
+++ b/utils/common_utils.py
@@ -77,7 +77,7 @@ def get_ena_library_terms_via_usi(logger):
                 if description["items"]["properties"]["value"].get("enum")}
 
 
-def get_ena_hardware_terms_via_usi(logger):
+def get_ena_instrument_terms_via_usi(logger):
     """Read ENA's controlled vocabulary using USI's API and
     return list of the instrument models that are allowed (enum)."""
 

--- a/utils/common_utils.py
+++ b/utils/common_utils.py
@@ -21,7 +21,7 @@ def create_logger(working_dir, process_name, object_name, log_level=20, logger_n
 
     # This handler is for writing to the log file
     hdlr = logging.FileHandler(log_file_path)
-    formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s : %(message)s')
+    formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s: %(message)s')
     hdlr.setFormatter(formatter)
     logger.addHandler(hdlr)
 

--- a/utils/common_utils.py
+++ b/utils/common_utils.py
@@ -67,13 +67,27 @@ def get_term_descendants(ontology, term_url, logger):
 
 def get_ena_library_terms_via_usi(logger):
     """Read ENA's controlled vocabulary using USI's API and
-    return dictionary of the field names with the allowed values."""
+    return dictionary of the field names that have a set of allowed values (enum)."""
 
     url = "https://submission-dev.ebi.ac.uk/api/dataTypes/sequencingExperiments"
     data = download_json(logger, url)
     if data:
-        return {field: description["items"]["properties"]["value"].get("enum", [])
-                for field, description in data["validationSchema"]["properties"]["attributes"]["properties"].items()}
+        return {field: description["items"]["properties"]["value"]["enum"]
+                for field, description in data["validationSchema"]["properties"]["attributes"]["properties"].items()
+                if description["items"]["properties"]["value"].get("enum")}
+
+
+def get_ena_hardware_terms_via_usi(logger):
+    """Read ENA's controlled vocabulary using USI's API and
+    return list of the instrument models that are allowed (enum)."""
+
+    url = "https://submission-dev.ebi.ac.uk/api/dataTypes/sequencingExperiments"
+    data = download_json(logger, url)
+    instruments = []
+    if data:
+        for x in data["validationSchema"]["properties"]["attributes"]["oneOf"]:
+            instruments.extend(x["properties"]["instrument_model"]["items"]["properties"]["value"]["enum"])
+        return instruments
 
 
 def download_json(logger, url, parameters=None):

--- a/utils/converter_utils.py
+++ b/utils/converter_utils.py
@@ -182,8 +182,9 @@ def get_sdrf_path(idf_file_path, logger, data_dir):
         for line in f:
             if re.search(SDRF_FILE_NAME_REGEX, line):
                 sdrf_file_name = line.split('\t')[1].strip()
-                if os.path.exists(os.path.join(current_dir, data_dir)):
-                    sdrf_file_path = os.path.join(current_dir, data_dir, sdrf_file_name)
+                data_path = os.path.join(current_dir, data_dir)
+                if os.path.exists(data_path):
+                    sdrf_file_path = os.path.join(data_path, sdrf_file_name)
                 else:
                     sdrf_file_path = os.path.join(current_dir, sdrf_file_name)
     logger.debug("Generated SDRF file path: {}".format(sdrf_file_path))

--- a/utils/converter_utils.py
+++ b/utils/converter_utils.py
@@ -161,7 +161,7 @@ def attrib2dict(ob):
     return attrib_dict
 
 
-def get_sdrf_path(idf_file_path, logger, data_dir=DEFAULT_DATA_DIRECTORY):
+def get_sdrf_path(idf_file_path, logger, data_dir):
     """Read IDF and get the SDRF file name, look for the SDRF in the data directory (i.e. "unpacked")
     or in the same directory as the IDF.
 
@@ -173,13 +173,15 @@ def get_sdrf_path(idf_file_path, logger, data_dir=DEFAULT_DATA_DIRECTORY):
 
     current_dir = os.path.dirname(idf_file_path)
     sdrf_file_path = ""
+    if not data_dir:
+        data_dir = DEFAULT_DATA_DIRECTORY
     # Figure out the name and location of sdrf files
     with codecs.open(idf_file_path, 'rU', encoding='utf-8') as f:
         # U flag makes it portable across in unix and windows (\n and \r\n are treated the same)
         for line in f:
             if re.search(SDRF_FILE_NAME_REGEX, line):
                 sdrf_file_name = line.split('\t')[1].strip()
-                if os.path.exists(current_dir + data_dir):
+                if os.path.exists(os.path.join(current_dir, data_dir)):
                     sdrf_file_path = os.path.join(current_dir, data_dir, sdrf_file_name)
                 else:
                     sdrf_file_path = os.path.join(current_dir, sdrf_file_name)

--- a/utils/converter_utils.py
+++ b/utils/converter_utils.py
@@ -101,6 +101,10 @@ def get_taxon(organism):
     """Return the NCBI taxonomy ID for a given species name."""
 
     if organism and organism not in organism_lookup:
+        # If we have more than one organism mixed in one sample - in the case assign the 'mixed
+        # sample' taxon_id (c.f. https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1427524)
+        if re.search(r" and | \+ ", organism):
+            return 1427524
         print("Looking up species in NCBI taxonomy. Please wait...")
         db = 'taxonomy'
         a = esearch(db=db, term=organism)
@@ -108,17 +112,8 @@ def get_taxon(organism):
             taxon_id = int(a['esearchresult']['idlist'][0])
             organism_lookup[organism] = taxon_id
             return taxon_id
-        except IndexError:
-            if re.search(r" and | \+ ", organism):
-                # It looks as if we have more than one organism mixed in one sample - in the case assign the 'mixed
-                # sample' taxon_id (c.f. https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1427524) - as
-                # per instructions on https://www.ebi.ac.uk/seqdb/confluence/display/GXA/Curation+Look-up
-                return 1427524
-            else:
-                print("Failed to retrieve organism data from ENA taxonomy service for: " + organism)
-        #except KeyError:
-        #    time.sleep(10)
-        #    return esearch(db, organism)
+        except:
+            print("Failed to retrieve organism data from ENA taxonomy service for: " + organism)
     else:
         return organism_lookup.get(organism)
 

--- a/utils/converter_utils.py
+++ b/utils/converter_utils.py
@@ -1,13 +1,14 @@
 import codecs
 import json
+import logging
 import os
-import re
 import pkg_resources
-import sys
+import re
 
 from collections import OrderedDict, defaultdict
 
 from utils.eutils import esearch
+
 
 USI_JSON_DIRECTORY = "usijson"
 SDRF_FILE_NAME_REGEX = r"^\s*SDRF\s*File"
@@ -97,7 +98,7 @@ def is_accession(accession, archive=None):
 organism_lookup = {}
 
 
-def get_taxon(organism):
+def get_taxon(organism, logger=logging.getLogger()):
     """Return the NCBI taxonomy ID for a given species name."""
 
     if organism and organism not in organism_lookup:
@@ -105,15 +106,15 @@ def get_taxon(organism):
         # sample' taxon_id (c.f. https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1427524)
         if re.search(r" and | \+ ", organism):
             return 1427524
-        print("Looking up species in NCBI taxonomy. Please wait...")
+        logger.info("Looking up species in NCBI taxonomy. Please wait...")
         db = 'taxonomy'
         a = esearch(db=db, term=organism)
         try:
             taxon_id = int(a['esearchresult']['idlist'][0])
             organism_lookup[organism] = taxon_id
             return taxon_id
-        except:
-            print("Failed to retrieve organism data from ENA taxonomy service for: " + organism)
+        except Exception as e:
+            logger.error("Failed to retrieve organism data from ENA taxonomy service for {} due to {}".format(organism, str(e)))
     else:
         return organism_lookup.get(organism)
 

--- a/utils/converter_utils.py
+++ b/utils/converter_utils.py
@@ -11,7 +11,7 @@ from utils.eutils import esearch
 
 USI_JSON_DIRECTORY = "usijson"
 SDRF_FILE_NAME_REGEX = r"^\s*SDRF\s*File"
-DATA_DIRECTORY = "unpacked"
+DEFAULT_DATA_DIRECTORY = "unpacked"
 
 
 def read_json_file(filename):
@@ -161,12 +161,13 @@ def attrib2dict(ob):
     return attrib_dict
 
 
-def get_sdrf_path(idf_file_path, logger):
+def get_sdrf_path(idf_file_path, logger, data_dir=DEFAULT_DATA_DIRECTORY):
     """Read IDF and get the SDRF file name, look for the SDRF in the data directory (i.e. "unpacked")
     or in the same directory as the IDF.
 
     :param idf_file_path: full or relative path to IDF file
     :param logger: log handler
+    :param data_dir: path to folder with SDRF
     :return: path to SDRF file
     """
 
@@ -178,8 +179,8 @@ def get_sdrf_path(idf_file_path, logger):
         for line in f:
             if re.search(SDRF_FILE_NAME_REGEX, line):
                 sdrf_file_name = line.split('\t')[1].strip()
-                if os.path.exists(current_dir + DATA_DIRECTORY):
-                    sdrf_file_path = os.path.join(current_dir, DATA_DIRECTORY, sdrf_file_name)
+                if os.path.exists(current_dir + data_dir):
+                    sdrf_file_path = os.path.join(current_dir, data_dir, sdrf_file_name)
                 else:
                     sdrf_file_path = os.path.join(current_dir, sdrf_file_name)
     logger.debug("Generated SDRF file path: {}".format(sdrf_file_path))

--- a/utils/term_translations.json
+++ b/utils/term_translations.json
@@ -67,7 +67,8 @@
     "SRASubmissionDate": "",
     "GEOReleaseDate": "",
     "GEOLastUpdateDate": "",
-    "TemplateType": ""
+    "TemplateType": "",
+    "AEAnonymousReview": ""
   },
   "node_terms": {
     "Source Name": "",

--- a/validator/metadata_validation.py
+++ b/validator/metadata_validation.py
@@ -362,12 +362,32 @@ def run_assay_checks(sub: datamodel.Submission, logger):
             if "array_design" in additional_attributes:
                 logger.error("Found sequencing assay \"{}\" with 'array design' attribute.".format(a.alias))
                 codes.append("ASSA-E10")
+            # Mandatory ENA library info
+            if not a.library_layout:
+                logger.error("Sequencing assay \"{}\" has no library layout specified.".format(a.alias))
+                codes.append("ASSA-E12")
+            elif a.library_layout.lower() == "paired":
+                if not a.nominal_length:
+                    logger.error("Paired-end assay \"{}\" has no nominal length specified.".format(a.alias))
+                    codes.append("ASSA-E15")
+                if not a.nominal_sdev:
+                    logger.error("Paired-end assay \"{}\" has no nominal sdev specified.".format(a.alias))
+                    codes.append("ASSA-E16")
+            if not a.library_source:
+                logger.error("Sequencing assay \"{}\" has no library source specified.".format(a.alias))
+                codes.append("ASSA-E13")
+            if not a.library_strategy:
+                logger.error("Sequencing assay \"{}\" has no library strategy specified.".format(a.alias))
+                codes.append("ASSA-E14")
+            if not a.library_strand:
+                logger.warn("Sequencing assay \"{}\" has no library strand specified.".format(a.alias))
+                codes.append("ASSA-W01")
             # ENA library terms must match against controlled vocabulary
             for term, cv in library_terms.items():
                 # Assuming here that the names of the fields are exactly the same as in the assay attributes
                 value = getattr(a, term)
-                if value not in cv:
-                    logger.error("Value \"{}\" for {} does not match against ENA's controlled vocabulary".format(value, term))
+                if value and value not in cv:
+                    logger.error("Value \"{}\" for {} does not match against ENA's controlled vocabulary.".format(value, term))
                     codes.append("ASSA-E11")
 
     return codes

--- a/validator/metadata_validation.py
+++ b/validator/metadata_validation.py
@@ -8,6 +8,7 @@ from utils.common_utils import get_term_descendants, get_ena_library_terms_via_u
 
 REGEX_DATE_FORMAT = re.compile("([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))")
 REGEX_DOI_FORMAT = re.compile("^10\.\d{4,9}\/\S+$")
+REGEX_FILE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
 def run_protocol_checks(sub: datamodel.Submission, logger):
@@ -451,7 +452,7 @@ def _data_object_checks(data_objects, logger, codes):
 def _file_object_checks(file_objects, logger, codes):
     for f in file_objects:
         if f.name:
-            if not re.match(r"^[A-Za-z0-9._-]+$", f.name):
+            if not REGEX_FILE_NAME.match(f.name):
                 logger.error("File name \"{}\" does not match allowed pattern.".format(f.name))
                 codes.append("DATA-E06")
         else:

--- a/validator/metadata_validation.py
+++ b/validator/metadata_validation.py
@@ -117,7 +117,7 @@ def run_sample_checks(sub: datamodel.Submission, logger):
     # Check organism name is in taxonomy
     for o in organisms:
         taxon_id = converter_utils.get_taxon(o)
-        logger.debug("Found taxon ID: ", taxon_id)
+        logger.debug("Found taxon ID: {}".format(taxon_id))
         if not isinstance(taxon_id, int):
             logger.error("Organism \"{}\" was not found in NCBI taxonomy.".format(o))
             codes.append("SAMP-E08")


### PR DESCRIPTION
This adds more checks to the assay object validation, more specifically checks for the sequencing library attributes. Presence of values and their match against ENA's controlled vocabulary are validated. 
I've also added two more options to the command line script to run the validation. It can now be pointed to a specific data directory where SDRF or data files might be located with -d option (which is equivalent to the validate_magetab.pl script) and verbose logging can be activated with -v. 
