### PR TITLE
JSON schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ This repository contains modules for transformation of experimental metadata bet
 ## Installation and requirements
 
 Python 3.6 interpreter<br>
-Package requirements: requests 2.20.1 <br>
+Package requirements:git 
+* requests 2.20.1
+* jsonschema 2.6.0
+
 Add usi-arrayexpress directory to PYTHONPATH environment variable
 
 

--- a/json_schemas/arrayexpress_analysis_schema.json
+++ b/json_schemas/arrayexpress_analysis_schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema":"http://json-schema.org/draft-07/schema#",
+  "title": "ArrayExpress Analysis Schema",
+  "description": "A schema describing the attributes of an analysis object submitted to ArrayExpress. An analyis object contains a processed data file derived from raw data. A 'processed matrix' file can contain references to more than one assay data object, while a 'processed' file should be linked to only one assay data object.",
+  "version": "1.0.0",
+  "author": "arrayexpress",
+  "type": "object",
+  "required": [
+    "alias",
+    "files",
+    "assayDataRefs"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "alias": {
+      "description": "A unique identifier for the data object.",
+      "type": "string",
+      "minLength": 1
+    },
+    "files": {
+      "description": "The list of the associated files.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "description": "The name of the file.",
+            "type": "string",
+            "pattern": "^[A-Za-z0-9._-]+$"
+          },
+          "checksum": {
+            "description": "The calculated checksum of the file.",
+            "type": "string"
+          },
+          "checksum_method": {
+            "description": "The method type of the checksum calculation.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "attributes": {
+      "description": "Attributes for describing a submittable.",
+      "type": "object",
+      "required": [
+        "data_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "data_type": {
+          "description": "The type of analysis data file.",
+          "type": "string",
+          "enum": [
+            "processed",
+            "processed matrix"
+          ]
+        }
+      },
+      "patternProperties": {
+        "^.*$": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "properties": {
+              "value": {
+                "type": "string",
+                "minLength": 1
+              },
+              "units": {
+                "type": "string",
+                "minLength": 1
+              },
+              "terms": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "value"
+            ]
+          }
+        }
+      }
+    },
+    "assayDataRefs": {
+      "description": "Reference(s) to assay_data objects.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/submittableRef"
+      }
+    }
+  },
+  "definitions": {
+    "submittableRef": {
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": "string",
+          "minLength": 1
+        },
+        "accession": {
+          "type": "string",
+          "minLength": 1
+        },
+        "team": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "alias",
+            "team"
+          ]
+        },
+        {
+          "required": [
+            "accession"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/json_schemas/arrayexpress_assay_data_schema.json
+++ b/json_schemas/arrayexpress_assay_data_schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema":"http://json-schema.org/draft-07/schema#",
+  "title": "ArrayExpress Assay Data Schema",
+  "description": "A schema describing the attributes of an assay data object submitted to ArrayExpress. An assay data object contains all raw data files belonging to one hybridisation or sequencing run/lane. A Raw Matrix file can contain references to more than one sample/assay. The assay data is equivalent to an ENA sequencing run.",
+  "version": "1.0.0",
+  "author": "arrayexpress",
+  "type": "object",
+  "required": [
+    "alias",
+    "files",
+    "assayRefs"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "alias": {
+      "description": "A unique identifier for the data object.",
+      "type": "string",
+      "minLength": 1
+    },
+    "files": {
+      "description": "The list of the associated files.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "description": "The name of the file.",
+            "type": "string",
+            "pattern": "^[A-Za-z0-9._-]+$"
+          },
+          "checksum": {
+            "description": "The calculated checksum of the file.",
+            "type": "string"
+          },
+          "checksum_method": {
+            "description": "The method type of the checksum calculation.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "attributes": {
+      "description": "Attributes for describing a submittable.",
+      "type": "object",
+      "required": [
+        "data_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "data_type": {
+          "description": "The type of data file.",
+          "type": "string",
+          "enum": [
+            "raw",
+            "raw matrix"
+          ]
+        }
+      },
+      "patternProperties": {
+        "^.*$": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "properties": {
+              "value": {
+                "type": "string",
+                "minLength": 1
+              },
+              "units": {
+                "type": "string",
+                "minLength": 1
+              },
+              "terms": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "value"
+            ]
+          }
+        }
+      }
+    },
+    "assayRefs": {
+      "description": "Reference(s) to assay(s).",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/submittableRef"
+      }
+    }
+  },
+  "definitions": {
+    "submittableRef": {
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": "string",
+          "minLength": 1
+        },
+        "accession": {
+          "type": "string",
+          "minLength": 1
+        },
+        "team": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "alias",
+            "team"
+          ]
+        },
+        {
+          "required": [
+            "accession"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/json_schemas/arrayexpress_microarray_assay_schema.json
+++ b/json_schemas/arrayexpress_microarray_assay_schema.json
@@ -1,0 +1,158 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ArrayExpress Microarray Assay Schema",
+    "description": "The schema describing the attributes of a microarray assay submitted to ArrayExpress. A microarray assay is roughly equivalent to a labeled extract in MAGE-TAB, which is used in a hybridisation reaction.",
+    "version": "1.0.0",
+    "author": "arrayexpress",
+    "type": "object",
+    "required": [
+            "alias",
+            "studyRef",
+            "protocolUses",
+            "sampleUses"
+        ],
+    "additionalProperties": false,
+    "properties": {
+        "alias": {
+            "description": "A unique identifier for the microarray assay.",
+            "type": "string",
+            "minLength": 1
+        },
+        "description": {
+            "description": "More extensive free-form description.",
+            "type": "string"
+        },
+        "attributes": {
+            "description": "Attributes for describing a microarray assay.",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "label",
+                "array_design",
+                "technology_type"
+            ],
+            "properties": {
+                "label": {
+                    "description": "The chemicals (e.g. Cy3 fluorescent dye) conjugated to nucleic acid to label them before microarray hybridisation. Experiments with Affymetrix or Illumina arrays usually use the label 'biotin'. Two-colour microarrays usually use Cy3 and Cy5.",
+                    "type": "string"
+                },
+                "array_design": {
+                    "description": "The ArrayExpress accession of the array design that was used for the hybridisation",
+                    "type": "string",
+                    "pattern": "^A-[A-Z]{4}-[0-9]+$"
+                },
+                "technology_type": {
+                    "description": "The type of technology used, sequencing or microarray assay.",
+                    "type": "string",
+                    "enum": [
+                        "array assay"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^.*$": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "units": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "terms": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {
+                                            "type": "string",
+                                            "format": "uri"
+                                        }
+                                    },
+                                    "required": [
+                                        "url"
+                                    ]
+                                }
+                            }
+                        },
+                        "required": [
+                            "value"
+                        ]
+                    }
+                }
+            }
+        },
+        "studyRef": {
+            "description": "Reference to study.",
+            "$ref": "#/definitions/submittableRef"
+        },
+        "protocolUses": {
+            "type": "array",
+            "minLength": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "protocolRef": { "$ref": "#/definitions/submittableRef" },
+                    "attributes": { "$ref": "#/definitions/attributes" }
+                }
+            }
+        },
+        "sampleUses": {
+            "type": "array",
+            "minLength": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "sampleRef": { "$ref": "#/definitions/submittableRef" },
+                    "attributes": { "$ref": "#/definitions/attributes" }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "attributes": {
+            "description": "Attributes for describing a sequencing assay.",
+            "type": "object",
+            "properties": {},
+            "patternProperties": {
+                "^.*$": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "properties": {
+                            "value": { "type": "string", "minLength": 1 },
+                            "units": { "type": "string", "minLength": 1 },
+                            "terms": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {"type": "string", "format": "uri" }
+                                    },
+                                    "required": ["url"]
+                                }
+                            }
+                        },
+                        "required": [ "value" ]
+                    }
+                }
+            }
+        },
+        "submittableRef": {
+			"type": "object",
+			"properties": {
+				"alias": { "type": "string", "minLength": 1 },
+				"accession": { "type": "string", "minLength": 1 },
+				"team": { "type": "string", "minLength": 1 }
+			},
+			"anyOf": [
+				{ "required": [ "alias", "team" ] },
+				{ "required": [ "accession" ] }
+			]
+        }
+    }
+}

--- a/json_schemas/arrayexpress_project_schema.json
+++ b/json_schemas/arrayexpress_project_schema.json
@@ -10,15 +10,29 @@
     "releaseDate",
     "contacts"
   ],
+  "additionalProperties": false,
   "properties": {
     "alias": {
       "description": "A unique identifier of the project",
       "type": "string",
       "minLength": 1
     },
+    "title": {
+      "description": "Title of the project.",
+        "type":	"string",
+        "minLength": 25,
+        "maxLength": 4000
+    },
+    "description": {
+      "description": "More extensive free-form description.",
+        "type":	"string",
+        "minLength": 50,
+        "maxLength": 4000
+    },
     "releaseDate": {
-      "description": "The date at which the project shall be made public",
+      "description": "The date at which the project shall be made public. Must be in DD-MM-YYYY format.",
       "type":  "string",
+      "format": "date",
       "pattern": "([12][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))"
     },
     "publications": {
@@ -31,6 +45,10 @@
             "description": "The title of the publication",
             "type": "string"
           },
+          "authors": {
+            "description": "A list of the manuscript authors",
+            "type": "string"
+          },
           "status": {
             "description": "The state in the publication process",
             "type": "string",
@@ -38,16 +56,13 @@
           },
           "pubmedId": {
             "description": "The accession number of the publication in the NCBI PubMed database",
-            "type": "integer"
-          },
-          "authors": {
-            "description": "A list of the manuscript authors",
-            "type": "string"
+            "type": "string",
+            "pattern":"^\\d+$"
           },
           "doi": {
             "description": "The digital object identifier of the publication (without 'http://')",
             "type": "string",
-            "pattern": "^10.[0-9]{4,9}/[-._;()/:A-Z0-9]+$"
+            "pattern": "^10\\.\\d{4,9}\\/\\S+$"
           }
         }
       }
@@ -67,6 +82,9 @@
         "lastName": {
           "type": "string"
         },
+        "middleInitials": {
+          "type": "string"
+        },
         "email": {
           "type": "string",
           "format": "email"
@@ -78,6 +96,12 @@
           "type": "string"
         },
         "phone": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        },
+        "fax": {
           "type": [
             "string",
             "integer"
@@ -106,6 +130,71 @@
               "software manufacturer",
               "submitter"
             ]
+          }
+        }
+      },
+      "contains": {
+        "description": "The contact information of the submitter",
+        "type": "object",
+        "required": [
+            "roles",
+            "firstName",
+            "lastName",
+            "email",
+            "affiliation"
+        ],
+        "properties": {
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "affiliation": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "phone": {
+            "type": [
+              "string",
+              "integer"
+            ]
+          },
+          "roles": {
+            "type": "array",
+            "minItems": 1,
+            "contains": {
+              "type": "string",
+              "enum": ["submitter"]
+            },
+            "items": {
+              "type": "string",
+              "enum": [
+                "array manufacturer",
+                  "biomaterial provider",
+                  "biosequence provider",
+                  "consortium member",
+                  "consultant",
+                  "curator",
+                  "data analyst",
+                  "data coder",
+                  "experiment performer",
+                  "funder",
+                  "hardware manufacturer",
+                  "institution",
+                  "investigator",
+                  "material supplier role",
+                  "peer review quality control role",
+                  "software manufacturer",
+                  "submitter"
+              ]
+            }
           }
         }
       }

--- a/json_schemas/arrayexpress_protocol_schema.json
+++ b/json_schemas/arrayexpress_protocol_schema.json
@@ -1,21 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ArrayExpress Protocol Schema",
-  "description": "Protocol schema for ArrayExpress submissions. Protocols describe an experimental procedure used to generate data from biological material.",
+  "description": "Protocol schema for ArrayExpress submissions. A protocol describes an experimental procedure used to generate data from biological material.",
   "version": "1.0.0",
   "author": "arrayexpress",
   "type": "object",
   "additionalProperties": false,
   "required": [
     "alias",
-    "title",
     "description"
     ],
   "properties": {
-    "title": {
-      "description": "The name or accession of the protocol.",
-      "type": "string"
-    },
     "alias": {
       "description": "Unique identifier of the protocol.",
       "type": "string"
@@ -24,53 +19,36 @@
       "description": "The protocol text, describing the methods used for the experimental or analysis step.",
       "type": "string"
     },
-    "team": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        }
-      }
-    },
-    "archive": {
-      "type": "string",
-      "enum": [
-        "ArrayExpress"
-      ]
-    },
     "attributes": {
       "description": "ArrayExpress protocol attributes.",
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "protocol_type"
       ],
       "properties": {
-        "additionalProperties": false,
         "protocol_type": {
-          "description": "The type of protocol. Must be child of protocol EFO term (http://purl.obolibrary.org/obo/OBI_0000272)."
-        },
-        "software": {
-          "description": "The type of software used for the procedure."
-        },
-        "hardware": {
-          "description": "The type of hardware used for the procedure. Mandatory for type nucleic acid sequencing protocol."
-        },
-        "performer": {
-          "description": "The person, institute or company who performed the procedure. Mandatory for type nucleic acid sequencing protocol."
-        },
-        "parameters": {
-          "description": "The parameters used or tested in the protocol, e.g. temperature, batch, PCR cycles."
-        }
-      },
-      "patternProperties": {
-        "^.*$": {
+          "description": "The type of protocol. Must be child of protocol EFO term (http://purl.obolibrary.org/obo/OBI_0000272).",
           "type": "array",
           "minItems": 1,
+          "maxItems": 1,
           "items": {
             "properties": {
               "value": {
                 "type": "string",
-                "minLength": 1
+                "minLength": 1,
+                "enum": [
+                  "sample collection protocol",
+                  "conversion protocol",
+                  "dissection protocol",
+                  "normalization data transformation protocol",
+                  "array scanning and feature extraction protocol",
+                  "nucleic acid hybridization to array protocol",
+                  "growth protocol",
+                  "nucleic acid labeling protocol",
+                  "nucleic acid extraction protocol",
+                  "treatment protocol"
+                ]
               },
               "units": {
                 "type": "string",
@@ -91,11 +69,20 @@
                   ]
                 }
               }
-            },
-            "required": [
-              "value"
-            ]
+            }
           }
+        },
+        "software": {
+          "description": "The type of software used for the procedure.",
+          "type": "string"
+        },
+        "hardware": {
+          "description": "The type of hardware used for the procedure. Mandatory for type nucleic acid sequencing protocol.",
+          "type": "string"
+        },
+        "performer": {
+          "description": "The person, institute or company who performed the procedure. Mandatory for type nucleic acid sequencing protocol.",
+          "type": "string"
         }
       }
     }

--- a/json_schemas/arrayexpress_sample_schema.json
+++ b/json_schemas/arrayexpress_sample_schema.json
@@ -1,0 +1,109 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ArrayExpress Submission Sample Schema",
+    "description": "A base validation sample schema",
+    "version": "1.0.0",
+    "author": "arrayexpress",
+    "type": "object",
+    "required": [
+      "alias",
+      "taxonId"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "alias": {
+            "description": "An unique identifier of the sample.",
+            "type": "string",
+            "pattern": "^[^#]",
+            "minLength": 1
+        },
+        "description": {
+            "description": "More extensive free-form description.",
+            "type": "string",
+            "minLength": 1
+        },
+        "taxonId": {
+            "description": "The taxon identifier from NCBI's taxonomy.",
+            "type": "integer",
+            "minimum": 1
+        },
+        "taxon": {
+            "description": "The genus and species of the organism. Should be the latin species name, e.g. Homo sapiens.",
+            "type": "string",
+            "minLength": 1
+        },
+        "releaseDate": {
+            "type": "string",
+            "format": "date"
+        },
+        "attributes": {
+            "description": "Attributes for describing a sample.",
+            "type": "object",
+            "required": [
+              "organism"
+            ],
+          "additionalProperties": true,
+            "properties": {
+                "material_type": {
+                    "description": "The type of source material.",
+                    "type": "string",
+                    "enum": [
+                      "whole organism",
+                      "organism part",
+                      "cell",
+                      "RNA",
+                      "DNA"
+                    ]
+                  },
+                "organism": {
+                    "description": "The genus and species of the organism. Should be the latin species name, e.g. Homo sapiens."
+                }
+            },
+            "patternProperties": {
+                "^.*$": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 1,
+                    "items": {
+                        "properties": {
+                            "value": { "type": "string", "minLength": 1 },
+                            "units": { "type": "string", "minLength": 1 },
+                            "terms": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {"type": "string", "format": "uri" }
+                                    },
+                                    "required": ["url"]
+                                }
+                            }
+                        },
+                        "required": ["value"]
+                    }
+                }
+            }
+        },
+        "sampleRelationships": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "alias": { "type": "string", "minLength": 1 },
+                    "accession": { "type": "string", "minLength": 1 },
+                    "team": { "type": "string", "minLength": 1 },
+                    "relationshipNature": {
+                        "type": "string",
+                        "enum": [ "derived from", "child of", "same as", "recurated from" ]
+                    }
+                },
+                "anyOf": [
+                    { "required": ["alias", "team", "relationshipNature"] },
+                    { "required": ["accession", "relationshipNature"] }
+                ]
+            }
+        }
+    }
+}
+
+

--- a/json_schemas/arrayexpress_sequencing_assay_schema.json
+++ b/json_schemas/arrayexpress_sequencing_assay_schema.json
@@ -1,0 +1,169 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ArrayExpress Sequencing Assay Schema",
+    "description": "The schema describing the attributes of a sequencing assay submitted to ArrayExpress",
+    "version": "1.0.0",
+    "author": "arrayexpress",
+    "type": "object",
+    "required": [
+            "alias",
+            "studyRef",
+            "protocolUses",
+            "sampleUses"
+        ],
+    "additionalProperties": false,
+    "properties": {
+        "alias": {
+            "description": "A unique identifier for the sequencing assay.",
+            "type": "string",
+            "minLength": 1
+        },
+        "description": {
+            "description": "More extensive free-form description.",
+            "type": "string"
+        },
+        "attributes": {
+            "description": "Attributes for describing a sequencing assay. CAN WE REFERENCE ENA's SCHEMA HERE? WHAT ELSE IS MANDATORY FOR ENA?",
+            "type": "object",
+            "required": [
+                "library_layout",
+                "library_source",
+                "library_strategy",
+                "library_selection",
+                "platform_type",
+                "instrument_model",
+                "technology_type"
+            ],
+            "additionalProperties": true,
+            "properties": {
+                "library_layout": {
+                    "description": "The layout of the sequencing library, SINGLE or PAIRED."
+                },
+                "library_source": {
+                    "description": "The source material of the sequencing library, e.g. TRANSCRIPTOMIC."
+                },
+                "library_strategy": {
+                    "description": "The type of sequencing approach, e.g. RNA-Seq."
+                },
+                "library_selection": {
+                    "description": "The selection strategy of the faction of nucleic acid that was sequenced."
+                },
+                "nominal_length": {},
+                "nominal_sdev": {},
+                "platform_type":{},
+                "instrument_model": {},
+                "technology_type": {
+                    "description": "The type of technology used, sequencing or microarray assay.",
+                    "type": "string",
+                    "enum": [
+                        "sequencing assay"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^.*$": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "units": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "terms": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {
+                                            "type": "string",
+                                            "format": "uri"
+                                        }
+                                    },
+                                    "required": [
+                                        "url"
+                                    ]
+                                }
+                            }
+                        },
+                        "required": [
+                            "value"
+                        ]
+                    }
+                }
+            }
+        },
+        "studyRef": {
+            "description": "Reference to study.",
+            "$ref": "#/definitions/submittableRef"
+        },
+        "protocolUses": {
+            "type": "array",
+            "minLength": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "protocolRef": { "$ref": "#/definitions/submittableRef" },
+                    "attributes": { "$ref": "#/definitions/attributes" }
+                }
+            }
+        },
+        "sampleUses": {
+            "type": "array",
+            "minLength": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "sampleRef": { "$ref": "#/definitions/submittableRef" },
+                    "attributes": { "$ref": "#/definitions/attributes" }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "attributes": {
+            "description": "Attributes for describing a sequencing assay.",
+            "type": "object",
+            "properties": {},
+            "patternProperties": {
+                "^.*$": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "properties": {
+                            "value": { "type": "string", "minLength": 1 },
+                            "units": { "type": "string", "minLength": 1 },
+                            "terms": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {"type": "string", "format": "uri" }
+                                    },
+                                    "required": ["url"]
+                                }
+                            }
+                        },
+                        "required": [ "value" ]
+                    }
+                }
+            }
+        },
+        "submittableRef": {
+			"type": "object",
+			"properties": {
+				"alias": { "type": "string", "minLength": 1 },
+				"accession": { "type": "string", "minLength": 1 },
+				"team": { "type": "string", "minLength": 1 }
+			},
+			"anyOf": [
+				{ "required": [ "alias", "team" ] },
+				{ "required": [ "accession" ] }
+			]
+        }
+    }
+}

--- a/json_schemas/arrayexpress_study_schema.json
+++ b/json_schemas/arrayexpress_study_schema.json
@@ -12,6 +12,7 @@
       "description",
       "protocolRefs"
     ],
+    "additionalProperties": false,
     "properties": {
         "alias": {
             "description": "A unique identifier of the study",
@@ -20,7 +21,9 @@
         },
         "title": {
             "description": "Title of the study",
-            "type": "string"
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
         },
         "description": {
             "description": "More extensive free-form description. Should describe the biological relevance and intent of the experiment, and include an experimental workflow.",
@@ -29,7 +32,7 @@
         },
         "studyType": {
             "type": "string",
-            "enum": [ "Sequencing", "FunctionalGenomics", "Metabolomics", "Proteomics" ]
+            "enum": ["FunctionalGenomics"]
         },
         "projectRef": {
             "description": "Reference to project",
@@ -44,22 +47,25 @@
             "description": "Attributes for describing a study",
             "type": "object",
             "required": [
-              "comment[aeexperimenttype]",
-              "experimental factor"
+              "experiment_type",
+              "experimental_factor"
             ],
+            "additionalProperties": false,
             "properties": {
-              "comment[aeexperimenttype]": {
-                "Description": "ArrayExpress experiment type, must be from EFO",
+              "experiment_type": {
+                "description": "ArrayExpress experiment type, must be from EFO"
               },
-              "experimental design": {
-                "Description": "The scientific design of the study, must be from EFO"
+              "experimental_design": {
+                "description": "The scientific design of the study, must be from EFO"
               },
-              "experimental factor": {
-                "Description": "The attributes in the study that describe the experimental groups",
+              "experimental_factor": {
+                "description": "The attributes in the study that describe the experimental groups"
               },
-              "date of experiment": {
-                "Description": "The date the experiment was performed",
-                "maxItems": 1
+              "date_of_experiment": {
+                "description": "The date the experiment was performed. Must be in DD-MM-YYYY format.",
+                "type": "string",
+                "format": "date",
+                "pattern": "([12][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))"
               }
             },
             "patternProperties": {

--- a/tests/test_schema_validity.py
+++ b/tests/test_schema_validity.py
@@ -1,0 +1,50 @@
+import unittest
+import os
+import jsonschema
+import json
+import re
+
+
+class TestJsonSchemasAndObjects(unittest.TestCase):
+
+    def setUp(self):
+        test_dir = os.path.dirname(os.path.abspath(__file__))
+        base_dir = os.path.dirname(test_dir)
+        self.schema_dir = os.path.join(base_dir, "json_schemas")
+        self.data_dir = os.path.join(test_dir, "test_data", "usijson")
+
+    def test_validate_json_schemas(self):
+
+        schema_files = [os.path.join(self.schema_dir, f) for f in os.listdir(self.schema_dir) if f.endswith(".json")]
+
+        for sf in schema_files:
+            print("Testing schema: {}".format(sf))
+            with open(sf) as js_file:
+                schema = json.load(js_file)
+                validator = jsonschema.Draft4Validator(schema)
+                validator.check_schema(schema)
+
+    def test_validate_json_object_against_schema(self):
+
+        test_objects = [os.path.join(self.data_dir, f) for f in os.listdir(self.data_dir) if f.endswith(".json")]
+
+        types = ("project", "study", "protocol", "sample", "assay_data", "analysis")
+        for test_file_name in test_objects:
+            with open(test_file_name) as tf:
+                test_object = json.load(tf)
+                for schema_name in types:
+                    # Find the fitting schema
+                    if re.search(schema_name, test_file_name):
+                        print("Testing {} against {} schema".format(test_file_name, schema_name))
+                        with open(os.path.join(self.schema_dir, "arrayexpress_{}_schema.json".format(schema_name))) as so:
+                            schema_object = json.load(so)
+                            # The file contains a list and only the individual elements are described by the schema
+                            if isinstance(test_object, list):
+                                for entry in test_object:
+                                    jsonschema.validate(entry, schema_object)
+                            else:
+                                jsonschema.validate(test_object, schema_object)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This creates a set of JSON schemas describing the JSON format for the submittables through USI. There is one schema per submittable (e.g. study, sample). There are separate schemas for assays as they are different depending on the type of technology (microarray vs. sequencing).
There are two unit tests: 1) checking the schemas' validity, using jsonschema package, which runs fine, 2) checking the JSON generated by the converter against the schemas. The second test currently fails because the converter and data model have not been updated yet to the changes made to the schemas. 
I am adding the files now into the develop branch to make the adjustments that have to be done to the converter and the data model easier (can check output against schemas).