### PR TITLE
Feature/singlecell validator

### DIFF
--- a/magetab_validation.py
+++ b/magetab_validation.py
@@ -75,6 +75,8 @@ def main():
     error_codes.extend(mv.run_sample_checks(sub, metadata_logger))
     error_codes.extend(mv.run_assay_checks(sub, metadata_logger))
     error_codes.extend(mv.run_file_checks(sub, metadata_logger))
+    if submission_type == "singlecell":
+        error_codes.extend(mv.run_singlecell_checks(sub, metadata_logger))
 
     if error_codes:
         logger.info("Validation finished with the following error codes: \n{}".format("\n".join(set(error_codes))))

--- a/utils/ontology_terms.json
+++ b/utils/ontology_terms.json
@@ -170,5 +170,31 @@
     "uri": "http://www.ebi.ac.uk/efo/EFO_0001742",
     "ontology": "EFO",
     "label": "publication status"
-  }
+  },
+  "singlecell_library_construction": [
+    "smart-seq",
+    "smart-seq2",
+    "smart-like",
+    "scrb-seq",
+    "mars-seq",
+    "cel-seq",
+    "cel-seq2",
+    "strt-seq",
+    "10xv1",
+    "10xv2",
+    "10xv3",
+    "drop-seq",
+    "other"
+  ],
+  "singlecell_isolation": [
+    "facs",
+    "fluidigm c1",
+    "10x",
+    "drop-seq",
+    "indrop",
+    "mouth pipette",
+    "cell picking",
+    "laser-capture microdissection",
+    "other"
+  ]
 }

--- a/utils/ontology_terms.json
+++ b/utils/ontology_terms.json
@@ -140,8 +140,10 @@
       "MNase-seq",
       "MRE-seq",
       "RIP-seq",
+      "Ribo-seq",
       "RNA-seq of coding RNA",
-      "RNA-seq of non coding RNA"
+      "RNA-seq of non coding RNA",
+      "RNA-seq of total RNA"
       ],
     "singlecell": [
       "RNA-seq of coding RNA from single cells",

--- a/validator/metadata_validation.py
+++ b/validator/metadata_validation.py
@@ -423,23 +423,36 @@ def run_singlecell_checks(sub: Submission, logger):
         sc_protocol = a.library_construction
         if not sc_protocol:
             logger.error("Single-cell assay \"{}\" has no library construction specified.".format(a.alias))
-            codes.append("CELL-01")
+            codes.append("CELL-E01")
         else:
             # Check that library_construction is from controlled vocabulary
             allowed_protocols = ontology_term("singlecell_library_construction")
             if sc_protocol.lower() not in allowed_protocols:
                 logger.error("Library construction \"{}\" for \"{}\" is not an allowed term.".
                              format(sc_protocol, a.alias))
-                codes.append("CELL-02")
+                codes.append("CELL-E02")
         # Check that sc assays have spike_in
         if not a.spike_in:
             logger.error("Single-cell assay \"{}\" has no spike in specified.".format(a.alias))
-            codes.append("CELL-03")
+            codes.append("CELL-E03")
         # Check that spike_in_dilution is in the correct format
         if a.spike_in_dilution:
             if not re.match("^1\:[0-9]+$", a.spike_in_dilution):
                 logger.error("Spike in dilution for \"{}\" does not match expected pattern.".format(a.alias))
-                codes.append("CELL-04")
+                codes.append("CELL-E04")
+        # Warnings about non-critical single cell attributes
+        if not a.single_cell_isolation:
+            logger.warn("Single-cell assay \"{}\" has no single cell isolation specified.").format(a.alias)
+            codes.append("CELL-W05")
+        if not a.end_bias:
+            logger.warn("Single-cell assay \"{}\" has no end bias specified.").format(a.alias)
+            codes.append("CELL-W06")
+        if not a.input_molecule:
+            logger.warn("Single-cell assay \"{}\" has no input molecule specified.").format(a.alias)
+            codes.append("CELL-W07")
+        if not a.primer:
+            logger.warn("Single-cell assay \"{}\" has no primer specified.").format(a.alias)
+            codes.append("CELL-W08")
 
     return codes
 

--- a/validator/metadata_validation.py
+++ b/validator/metadata_validation.py
@@ -1,6 +1,7 @@
 import re
 
 from converter.datamodel.submission import Submission
+from converter.datamodel.assay import SingleCellAssay
 from utils import converter_utils
 from utils.converter_utils import ontology_term, is_accession
 from utils.common_utils import get_term_descendants, get_ena_library_terms_via_usi, get_ena_instrument_terms_via_usi
@@ -405,6 +406,40 @@ def run_assay_checks(sub: Submission, logger):
                 if value and value not in cv:
                     logger.error("Value \"{}\" for {} does not match against ENA's controlled vocabulary.".format(value, term))
                     codes.append("ASSA-E11")
+
+    return codes
+
+
+def run_singlecell_checks(sub: Submission, logger):
+
+    codes = []
+
+    # Assay checks
+    for a in sub.assay:
+        if not isinstance(a, SingleCellAssay):
+            logger.warn("Assay \"{}\" is not a single-cell assay, skipping assay checks.")
+            continue
+        # Check that sc assays have library construction
+        sc_protocol = a.library_construction
+        if not sc_protocol:
+            logger.error("Single-cell assay \"{}\" has no library construction specified.".format(a.alias))
+            codes.append("CELL-01")
+        else:
+            # Check that library_construction is from controlled vocabulary
+            allowed_protocols = ontology_term("singlecell_library_construction")
+            if sc_protocol.lower() not in allowed_protocols:
+                logger.error("Library construction \"{}\" for \"{}\" is not an allowed term.".
+                             format(sc_protocol, a.alias))
+                codes.append("CELL-02")
+        # Check that sc assays have spike_in
+        if not a.spike_in:
+            logger.error("Single-cell assay \"{}\" has no spike in specified.".format(a.alias))
+            codes.append("CELL-03")
+        # Check that spike_in_dilution is in the correct format
+        if a.spike_in_dilution:
+            if not re.match("^1\:[0-9]+$", a.spike_in_dilution):
+                logger.error("Spike in dilution for \"{}\" does not match expected pattern.".format(a.alias))
+                codes.append("CELL-04")
 
     return codes
 


### PR DESCRIPTION
This adds validation checks for single cell assays equivalent to Annotare's current pre-submission validation in the single cell template. 
I've also added an option to the magetab_validation.py script (that runs metadata validation off MAGE-TAB files) to force the submission type, as the submission type is now a central argument that needs to be specified correctly in order to run the correct checks. 