### PR TITLE
Write submission envelope JSON

### DIFF
--- a/converter/dm2json.py
+++ b/converter/dm2json.py
@@ -246,6 +246,7 @@ def datamodel2json_conversion(submission, working_dir, logger, write_envelope=Fa
     :param submission: object, Submission class object that holds metadata of the whole experiment
     :param working_dir: string, directory to write files to
     :param logger: object, log handler
+    :param write_envelope: boolean, flag to package objects into one submission envelope JSON file
     :return: None
     """
 
@@ -269,8 +270,8 @@ def datamodel2json_conversion(submission, working_dir, logger, write_envelope=Fa
             if objects:
                 logger.info("Writing JSON file for {} to {}.".format(submittable_type, working_dir))
                 write_json_file(working_dir, objects, submittable_type, submission.info)
-
-    # Write submission envelope with all USI objects
-    logger.info("Writing JSON envelope file to {}.".format(working_dir))
-    write_json_file(working_dir, envelope, "envelope", submission.info)
+    else:
+        # Write submission envelope with all USI objects
+        logger.info("Writing JSON envelope file to {}.".format(working_dir))
+        write_json_file(working_dir, envelope, "envelope", submission.info)
 

--- a/converter/dm2json.py
+++ b/converter/dm2json.py
@@ -250,19 +250,27 @@ def datamodel2json_conversion(submission, working_dir, logger, envelope=False):
     """
 
     # Dict to store USI objects to write to file:
-    json_objects = {
-        "project": generate_usi_project_object(submission.project),
-        "study": generate_usi_study_object(submission.study, submission.info),
-        "protocol": [generate_usi_protocol_object(p) for p in submission.protocol],
-        "sample": [generate_usi_sample_object(s) for s in submission.sample],
-        "assay": [generate_usi_assay_object(a, submission.info) for a in submission.assay],
-        "assay_data": [generate_usi_data_object(ad, submission.info) for ad in submission.assay_data]
+    envelope = {
+        "submission": {},
+        "projects": [generate_usi_project_object(submission.project)],
+        "studies": [generate_usi_study_object(submission.study, submission.info)],
+        "protocols": [generate_usi_protocol_object(p) for p in submission.protocol],
+        "samples": [generate_usi_sample_object(s) for s in submission.sample],
+        "assays": [generate_usi_assay_object(a, submission.info) for a in submission.assay],
+        "assayData": [generate_usi_data_object(ad, submission.info) for ad in submission.assay_data]
     }
     # Analysis is optional
     if submission.analysis:
-        json_objects["analysis"] = [generate_usi_analysis_object(a, submission.info) for a in submission.analysis]
+        envelope["analyses"] = [generate_usi_analysis_object(a, submission.info) for a in submission.analysis]
 
-    # Write individual JSON files
-    for submittable_type, objects in json_objects.items():
-        logger.info("Writing JSON file for {}.".format(submittable_type))
-        write_json_file(working_dir, objects, submittable_type, submission.info)
+    if not envelope:
+        # Write individual JSON files
+        for submittable_type, objects in envelope.items():
+            if objects:
+                logger.info("Writing JSON file for {}.".format(submittable_type))
+                write_json_file(working_dir, objects, submittable_type, submission.info)
+
+    # Write submission envelope with all USI objects
+    logger.info("Writing JSON envelope file.")
+    write_json_file(working_dir, envelope, "envelope", submission.info)
+

--- a/converter/dm2json.py
+++ b/converter/dm2json.py
@@ -239,7 +239,7 @@ def generate_usi_ref_object(alias, sub_info, accession=None):
     return ref_object
 
 
-def datamodel2json_conversion(submission, working_dir, logger):
+def datamodel2json_conversion(submission, working_dir, logger, envelope=False):
     """
     Take metadata in common datamodel and write JSON files
 

--- a/converter/dm2json.py
+++ b/converter/dm2json.py
@@ -239,7 +239,7 @@ def generate_usi_ref_object(alias, sub_info, accession=None):
     return ref_object
 
 
-def datamodel2json_conversion(submission, working_dir, logger, envelope=False):
+def datamodel2json_conversion(submission, working_dir, logger, write_envelope=False):
     """
     Take metadata in common datamodel and write JSON files
 
@@ -263,14 +263,14 @@ def datamodel2json_conversion(submission, working_dir, logger, envelope=False):
     if submission.analysis:
         envelope["analyses"] = [generate_usi_analysis_object(a, submission.info) for a in submission.analysis]
 
-    if not envelope:
+    if not write_envelope:
         # Write individual JSON files
         for submittable_type, objects in envelope.items():
             if objects:
-                logger.info("Writing JSON file for {}.".format(submittable_type))
+                logger.info("Writing JSON file for {} to {}.".format(submittable_type, working_dir))
                 write_json_file(working_dir, objects, submittable_type, submission.info)
 
     # Write submission envelope with all USI objects
-    logger.info("Writing JSON envelope file.")
+    logger.info("Writing JSON envelope file to {}.".format(working_dir))
     write_json_file(working_dir, envelope, "envelope", submission.info)
 

--- a/mtab2usi_conversion.py
+++ b/mtab2usi_conversion.py
@@ -53,7 +53,7 @@ def main():
     sub = data_objects_from_magetab(idf_file, sdrf_file_path, submission_type)
 
     # Dump data in common data model as USI-JSON files
-    datamodel2json_conversion(sub, outdir, logger, envelope=args.envelope)
+    datamodel2json_conversion(sub, outdir, logger, write_envelope=args.envelope)
 
 
 if __name__ == '__main__':

--- a/mtab2usi_conversion.py
+++ b/mtab2usi_conversion.py
@@ -5,7 +5,7 @@ This script takes an IDF file as input and runs metadata conversion from MAGE-TA
 """
 
 import argparse
-import os
+from os.path import isdir, split
 
 from utils.common_utils import create_logger, file_exists
 from utils.converter_utils import get_sdrf_path, guess_submission_type
@@ -17,20 +17,30 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('idf',
                         help="name of MAGE-TAB IDF file")
+    parser.add_argument('-o', '--outdir',
+                        help="Path where to write the JSON file(s)")
+    parser.add_argument('-e', '--envelope', action='store_true',
+                        help="Option to output only one submission envelope type JSON file")
 
     args = parser.parse_args()
 
-    return args.idf
+    return args
 
 
 def main():
     process_name = "mtab2usi_conversion"
 
-    idf_file = parse_args()
+    args = parse_args()
+    idf_file = args.idf
     file_exists(idf_file)
 
+    # Output directory
+    current_dir, idf_file_name = split(idf_file)
+    outdir = current_dir
+    if args.outdir and isdir(args.outdir):
+        outdir = args.outdir
+
     # Create logger
-    current_dir, idf_file_name = os.path.split(idf_file)
     logger = create_logger(current_dir, process_name, idf_file_name)
 
     # Get path to SDRF file
@@ -43,7 +53,7 @@ def main():
     sub = data_objects_from_magetab(idf_file, sdrf_file_path, submission_type)
 
     # Dump data in common data model as USI-JSON files
-    datamodel2json_conversion(sub, current_dir, logger)
+    datamodel2json_conversion(sub, outdir, logger, envelope=args.envelope)
 
 
 if __name__ == '__main__':

--- a/utils/converter_utils.py
+++ b/utils/converter_utils.py
@@ -11,7 +11,6 @@ from collections import OrderedDict, defaultdict
 from utils.eutils import esearch
 
 
-USI_JSON_DIRECTORY = "usijson"
 SDRF_FILE_NAME_REGEX = r"^\s*SDRF\s*File"
 DEFAULT_DATA_DIRECTORY = "unpacked"
 
@@ -42,7 +41,7 @@ def usi_object_file_name(object_type, study_info):
 def write_json_file(wd, json_object, object_type, sub_info):
 
     json_file_name = usi_object_file_name(object_type, sub_info)
-    json_file_path = os.path.join(wd, USI_JSON_DIRECTORY, json_file_name)
+    json_file_path = os.path.join(wd, json_file_name)
     os.makedirs(os.path.dirname(json_file_path), exist_ok=True)
     with codecs.open(json_file_path, 'w', encoding='utf-8') as jf:
         json.dump(json_object, jf)


### PR DESCRIPTION
Previously each submittable produced a separate JSON file when running the mtab2usi converter script. This change makes it possible to compile a single JSON file that resembles the USI submission envelope JSON. This envelope can then be further parsed by the json2mtab converter. 
It also add an option to specify the output directory for JSON file as command line argument and a flag to switch on envelope generation. 