### PR TITLE
Improvements on MAGE-TAB writer

### DIFF
--- a/converter/dm2json.py
+++ b/converter/dm2json.py
@@ -3,7 +3,7 @@
 from collections import OrderedDict, defaultdict
 
 from datamodel.components import Attribute
-from utils.converter_utils import is_accession, get_efo_url, write_json_file, attrib2dict
+from utils.converter_utils import is_accession, get_efo_url, write_json_file, attrib2dict, get_controlled_vocabulary
 
 
 def generate_usi_project_object(project):
@@ -43,6 +43,17 @@ def generate_usi_study_object(study, sub_info):
     # Optional attributes
     if study.date_of_experiment:
         study_attributes["date_of_experiment"] = generate_usi_attribute_entry(study.date_of_experiment)
+    if study.secondary_accession:
+        for acc in study.secondary_accession:
+            study_attributes["secondary_accession"].extend(generate_usi_attribute_entry(acc))
+    if study.related_experiment:
+        for acc in study.related_experiment:
+            study_attributes["related_study"].extend(generate_usi_attribute_entry(acc))
+
+    # Comments
+    for comment, values in study.comments.items():
+        for v in values:
+            study_attributes["Comment[{}]".format(comment)].extend(generate_usi_attribute_entry(v))
 
     study_object["attributes"] = study_attributes
 
@@ -73,6 +84,8 @@ def generate_usi_sample_object(sample):
 
     if sample.description:
         sample_object['description'] = sample.description
+    if sample.material_type:
+        sample.attributes["material_type"] = Attribute(value=sample.material_type)
 
     attributes = OrderedDict()
     for a_name, a_attrib in sample.attributes.items():

--- a/converter/dm2magetab.py
+++ b/converter/dm2magetab.py
@@ -42,9 +42,9 @@ def generate_idf(sub):
         ("Publication Status Term Source REF", ["EFO" for p in sub.project.publications if p.publicationStatus]),
         ("Publication Status Term Accession Number", []),
         ("Protocol Name", [p.alias for p in sub.protocol]),
-        ("Protocol Type", [p.protocol_type.value for p in sub.protocol]),
-        ("Protocol Term Source REF", [p.protocol_type.term_source for p in sub.protocol]),
-        ("Protocol Term Accession Number", [p.protocol_type.term_accession for p in sub.protocol]),
+        ("Protocol Type", [p.protocol_type.value for p in sub.protocol if p.protocol_type]),
+        ("Protocol Term Source REF", [p.protocol_type.term_source for p in sub.protocol if p.protocol_type]),
+        ("Protocol Term Accession Number", [p.protocol_type.term_accession for p in sub.protocol if p.protocol_type]),
         ("Protocol Description", [p.description for p in sub.protocol]),
         ("Protocol Hardware", [p.hardware for p in sub.protocol]),
         ("Protocol Software", [p.software for p in sub.protocol]),
@@ -347,7 +347,7 @@ def sort_protocol_refs_to_dict(protocol_positions, all_protocols, sep="~~~"):
     protocol_dict = defaultdict(OrderedDict)
 
     for pos, p_types in protocol_positions.items():
-        prefs_for_position = [p for p in all_protocols if p.protocol_type.value in p_types]
+        prefs_for_position = [p for p in all_protocols if p.protocol_type and p.protocol_type.value in p_types]
         # Number of entries in the dict corresponds to the number of columns that will be created and
         # should be equal of the number of protocol refs for the same position
         column_number = 1

--- a/converter/dm2magetab.py
+++ b/converter/dm2magetab.py
@@ -6,7 +6,7 @@ import re
 from collections import OrderedDict, defaultdict
 
 from utils.common_utils import get_ontology_source_file
-from utils.converter_utils import get_controlled_vocabulary, new_file_prefix
+from utils.converter_utils import get_controlled_vocabulary, new_file_prefix, dict_to_vertical_table
 
 
 def generate_idf(sub):
@@ -386,6 +386,16 @@ def write_sdrf_file(pandas_table, new_file_name, logger):
         pandas_table.to_csv(new_file_name, sep='\t', encoding='utf-8', index=False)
     except Exception as e:
         logger.error("Failed to write SDRF: {}".format(str(e)))
+
+
+def write_idf_file(idf, new_idf_file, logger):
+    """Write out IDF tab-delimited text file from dictionary
+
+    :param idf: dictionary with IDF fields as keys
+    :param new_idf_file, file path to write IDF
+    :param logger: log for errors
+    """
+    return dict_to_vertical_table(idf, new_idf_file, logger)
 
 
 def get_term_sources(sub):

--- a/converter/json2dm.py
+++ b/converter/json2dm.py
@@ -235,9 +235,9 @@ class JSONConverter:
         return [self.import_string(element, translation)]
 
     @staticmethod
-    def get_first_object_from_list(input_json,  translation={}):
+    def get_first_object_from_list(input_json, default={}, translation={}):
         """Return the first object from a list or an empty dictionary if the list is empty."""
-        return next(iter(input_json), [])
+        return next(iter(input_json), default)
 
     @staticmethod
     def import_as_is(input_json, translation={}):

--- a/converter/magetab2dm.py
+++ b/converter/magetab2dm.py
@@ -437,7 +437,10 @@ def parse_idf(idf_file):
             # Remove empty list entries, e.g. 'related experiment': ['E-MTAB-7236', '', '', '']
             comment_values = [x for x in idf_dict[idf_ct] if x]
             # A new dict entry for the term with the list of values
-            study_info["comments"][usi_ct] = comment_values
+            if usi_ct:
+                study_info["comments"][usi_ct] = comment_values
+            else:
+                study_info["comments"][idf_ct] = comment_values
 
     # General Info
     general_terms = {get_name(t): val for t, val in get_controlled_vocabulary("investigation_terms").items()}
@@ -526,6 +529,7 @@ def data_objects_from_magetab(idf_file_path, sdrf_file_path, submission_type):
 
     # Study
     study_object = study_from_magetab(study_info)
+    print(study_object)
 
     # Protocols
     protocol_objects = []
@@ -701,7 +705,9 @@ def study_from_magetab(study_info):
     protocolrefs = study_info.get("protocolRefs", [])
     date_of_experiment = study_info.get("date_of_experiment", None)
     comments = study_info.get("comments", {})
-    experiment_type = comments.get("experiment_type", [])
+    experiment_type = comments.pop("experiment_type", [])
+    secondary_accession = comments.pop("secondary_accession", [])
+    related_experiment = comments.pop("related_experiment", [])
 
     return Study(alias=alias,
                  accession=accession,
@@ -712,7 +718,10 @@ def study_from_magetab(study_info):
                  experimental_factor=ef_objects,
                  experimental_design=ed_objects,
                  experiment_type=experiment_type,
-                 date_of_experiment=date_of_experiment)
+                 date_of_experiment=date_of_experiment,
+                 secondary_accession=secondary_accession,
+                 related_experiment=related_experiment,
+                 comments=comments)
 
 
 def protocol_from_magetab(protocol_dict):

--- a/json_schemas/arrayexpress_study_schema.json
+++ b/json_schemas/arrayexpress_study_schema.json
@@ -79,7 +79,7 @@
                   }
                 }
               },
-              "related_experiment": {
+              "related_study": {
                 "description": "Accession numbers of other studies that are related to the current submission, e.g. for multi-omics studies. These accessions can be from ArrayExpress or other archives such as PRIDE, ENA etc."
               },
               "secondary_accession": {

--- a/tests/run_mage2mage_via_json_conversion.py
+++ b/tests/run_mage2mage_via_json_conversion.py
@@ -35,6 +35,8 @@ def parse_args():
                         help="Option to output detailed logging (debug level)")
     parser.add_argument('-l', '--logdir',
                         help="The path where to write the log. Default is same directory as IDF file.")
+    parser.add_argument('-k', '--key', default='ae',
+                        help="The import key used to determine the conversion rules (default is 'ae')")
 
     return parser.parse_args()
 
@@ -90,10 +92,10 @@ def main():
     json_data = read_json_file(json_file)
 
     # Convert from JSON to data model
-    mapping_file = pkg_resources.resource_string("converter", "config/mapping_ae-usi_to_datamodel.json")
-    mapping = json.loads(mapping_file)
-    ae_converter = JSONConverter(mapping, import_key="ae")
-    sub2 = ae_converter.convert_usi_sub(json_data, source_file_name=json_file)
+    mapping = json.loads(pkg_resources.resource_string('datamodel',
+                                                       os.path.join("config", "datamodel_mapping_config.json")))
+    ae_converter = JSONConverter(mapping, import_key=args.key)
+    sub2 = ae_converter.convert_submission(json_data, source_file_name=json_file)
 
     # Run metadata validation again
     error_codes = []

--- a/utils/converter_utils.py
+++ b/utils/converter_utils.py
@@ -372,5 +372,5 @@ def new_file_prefix(sub):
         return sub.study.accession
     else:
         # Use prefix of original file name after stripping file extension
-        source_file = sub.info.get("metadata")
-        return re.sub("\.\w+$", "", os.path.basename(source_file), flags=re.IGNORECASE)
+        source_file = sub.info.get("metadata", "")
+        return re.sub(r"\.\w+$", "", os.path.basename(source_file), flags=re.IGNORECASE)

--- a/utils/term_translations.json
+++ b/utils/term_translations.json
@@ -54,9 +54,9 @@
   "idf_comment_terms": {
     "ArrayExpressAccession": "accession",
     "AEExperimentType": "experiment_type",
-    "RelatedExperiment": "",
+    "RelatedExperiment": "related_experiment",
     "AdditionalFile": "",
-    "SecondaryAccession": "",
+    "SecondaryAccession": "secondary_accession",
     "SequenceDataURI": "",
     "AEExperimentDisplayName": "",
     "EAExpectedClusters": "",


### PR DESCRIPTION
First set of improvements on the MAGE-TAB writer. 
The main changes are
- Support for related experiment and secondary accessions
- Re-arrangement of sample attributes so that they don't appear twice and use MAGE-TAB fields
- An automatic builder for the sequence data URI comment
- Make protocol_type optional 
