### PR TITLE
Feature/modular sdrf

### DIFF
--- a/converter/dm2json.py
+++ b/converter/dm2json.py
@@ -41,6 +41,8 @@ def generate_usi_study_object(study, sub_info):
         study_attributes["experiment_type"].extend(generate_usi_attribute_entry(et))
 
     # Optional attributes
+    if study.submission_type:
+        study_attributes["submission_type"] = generate_usi_attribute_entry(study.submission_type)
     if study.date_of_experiment:
         study_attributes["date_of_experiment"] = generate_usi_attribute_entry(study.date_of_experiment)
     if study.secondary_accession:

--- a/converter/dm2magetab.py
+++ b/converter/dm2magetab.py
@@ -175,6 +175,9 @@ def generate_sdrf(sub):
                 else:
                     if ad.accession:
                         assay_values.append(("Comment[ENA_RUN]", ad.accession))
+                    else:
+                        assay_values.append(("Comment[RUN]", ad.alias))
+
                     row3 = row2[:] + [protocol_refs[4], OrderedDict(assay_values)]
 
                 # Get all data files
@@ -182,7 +185,7 @@ def generate_sdrf(sub):
 
                 # Special layout for droplet datasets, produces one row per assay_data not per raw data file
                 if submission_type == "singlecell" and is_droplet(ad):
-                    droplet_data_files(ad, data_values)
+                    add_droplet_data_files(ad, data_values)
                     row4 = row3[:] + [OrderedDict(data_values)]
                     end_row(protocol_positions, all_protocols, ad, assay, sample, sub, rows, row4)
                     continue
@@ -381,7 +384,7 @@ def sort_protocol_refs_to_dict(protocol_positions, all_protocols, sep="~~~"):
     protocol_dict = defaultdict(OrderedDict)
 
     for pos, p_types in protocol_positions.items():
-        prefs_for_position = [p for p in all_protocols if p.protocol_type and p.protocol_type.value in p_types]
+        prefs_for_position = [p for p in all_protocols if p and p.protocol_type.value in p_types]
         # Number of entries in the dict corresponds to the number of columns that will be created and
         # should be equal of the number of protocol refs for the same position
         column_number = 1
@@ -532,7 +535,7 @@ def is_droplet(ad):
     return False
 
 
-def droplet_data_files(ad, data_values, sep="~~~"):
+def add_droplet_data_files(ad, data_values, sep="~~~"):
     """Droplet experiments can have >2 files per assay_data and need additional metadata about the read type of each.
     This produces a special type of SDRF where each assay_data (run) has a separate row instead of each file.
     The output ouf this function is just adding all file information as Comments and using the assay_data alias

--- a/converter/dm2magetab.py
+++ b/converter/dm2magetab.py
@@ -275,9 +275,15 @@ def end_row(protocol_positions, all_protocols, assay_data, assay, sample, sub, r
 
     protocol_refs = sort_protocol_refs_to_dict(protocol_positions, all_protocols)
 
-    row.extend([protocol_refs[6],
-                OrderedDict(processed_data_values),
-                OrderedDict(factor_values)])
+    if processed_data_values:
+        row.extend([protocol_refs[6],
+                    OrderedDict(processed_data_values),
+                    OrderedDict(factor_values)])
+    else:
+        row.extend([OrderedDict(),
+                    OrderedDict(processed_data_values),
+                    OrderedDict(factor_values)])
+
     rows.append(row)
 
 

--- a/converter/magetab2dm.py
+++ b/converter/magetab2dm.py
@@ -528,7 +528,7 @@ def data_objects_from_magetab(idf_file_path, sdrf_file_path, submission_type):
     project_object = project_from_magetab(study_info)
 
     # Study
-    study_object = study_from_magetab(study_info)
+    study_object = study_from_magetab(study_info, sub_info)
     print(study_object)
 
     # Protocols
@@ -685,7 +685,8 @@ def project_from_magetab(study_info):
                    contacts=contacts)
 
 
-def study_from_magetab(study_info):
+def study_from_magetab(study_info, sub_info):
+    submission_type = sub_info.get("submission_type")
     accession = study_info.get("accession")
     idf_file = os.path.basename(study_info.get("idf_filename", ""))
     alias = re.sub(r"\.idf\.txt$", "", idf_file)
@@ -723,6 +724,7 @@ def study_from_magetab(study_info):
                  experimental_design=ed_objects,
                  experiment_type=experiment_type,
                  date_of_experiment=date_of_experiment,
+                 submission_type=submission_type,
                  secondary_accession=secondary_accession,
                  related_experiment=related_experiment,
                  ea_curator=ea_curator,


### PR DESCRIPTION
- Write FASTQ_URI for sequencing data instead of ArrayExpress FTP file
- New logic for droplet data: If read_type is populated, we'll gather all file attributes in a single row with read type and FASTQ_URI columns
- Writing submission_type into the study attributes for data from MAGE-TAB
- Removing a trailing Protocol REF column for normalisation protocols that are not used (if no processed data is present)